### PR TITLE
FIX: `period.days` modified inside schema

### DIFF
--- a/src/sections/budgets/common/spending-bar.tsx
+++ b/src/sections/budgets/common/spending-bar.tsx
@@ -11,7 +11,7 @@ type SpendingBarProps = ActualNominal & {
 
 export const SpendingBar = ({ actual, nominal, remaining }: SpendingBarProps) => {
   const getValue = useCallback(() => {
-    if (nominal.amount === 0) return actual.amount >= 0 ? 100 : 0;
+    if (nominal.amount === 0) return actual.amount > 0 ? 100 : 0;
     if ((nominal.amount < 0 && actual.amount < 0) || (nominal.amount > 0 && actual.amount > 0))
       return Math.min(100, (100 * actual.amount) / nominal.amount);
     return 0;

--- a/src/types/category/schema.ts
+++ b/src/types/category/schema.ts
@@ -65,7 +65,7 @@ const PeriodSchema = z
     truncate: z.nativeEnum(TruncateMode),
   })
   .refine((value) => {
-    if (value.truncate === TruncateMode.Split) return (value.days = datesDays(value.dates));
+    if (value.truncate === TruncateMode.Split) return (value.days !== datesDays(value.dates));
     return true;
   }, "Only truncated periods may be split");
 


### PR DESCRIPTION
This would cause `period.days` to equal the number of days in the period **after** truncating, which is exactly what we don't want. This fix causes the schema to work properly.

Also make spending bars empty when nominal and actual amounts are both zero.